### PR TITLE
Ensures the installation of the gdebi package runs uninteractively.

### DIFF
--- a/linux_installer/install-template-gui.sh
+++ b/linux_installer/install-template-gui.sh
@@ -4,7 +4,7 @@
 #install dependencies
 sudo apt-get update
 
-sudo apt-get install gdebi
+sudo apt-get install gdebi -y
 
 mydir="${0%/*}"
 


### PR DESCRIPTION
Installing the gdebi package will prompt the user for a confirmation to install more packages. Since it's a GUI installer, the process is stalled awaiting a confirmation from the user that will never come.

This fixes https://github.com/Bitbloq/QSSWeb2Board/issues/28