### PR TITLE
A fresh QSSWeb2Board install doesn't create the `/opt/QSSWeb2Board/tm…

### DIFF
--- a/src/QSSWeb2Board/arduinohandler.cpp
+++ b/src/QSSWeb2Board/arduinohandler.cpp
@@ -153,6 +153,11 @@ bool ArduinoHandler::writeSketch(QString _sketch, QString _sketchName){
     QString sketchPath= sketchesBaseDir + sketchName + "/";
     QString sketchWithPath = sketchPath + sketchFileName;
 
+    //ensures the sketches folder is created
+    if(!QDir().exists(sketchesBaseDir)){
+        if(!QDir().mkdir(sketchesBaseDir))
+            throw DirNotCreatedException("Cannot create sketches base dir in " + sketchesBaseDir);
+    }
 
     //if there is a sketch with the same name remove
     if(QFile().exists(sketchWithPath)){


### PR DESCRIPTION
…p/sketches` folder.

An attempt to create a sketch subfolder will fail, because you can't create the `sketches/whatever` in one shot.

With this change we ensure the sketches folder is created before trying to create the specific sketch subfolder

Fixes https://github.com/Bitbloq/QSSWeb2Board/issues/30